### PR TITLE
fix(ci): force workflow to fail on unmatched files

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -50,6 +50,7 @@ jobs:
           draft: true
           files: Fishstrap-${{ github.ref_name }}.exe
           name: Fishstrap ${{ github.ref_name }}
+          fail_on_unmatched_files: true
 
   release-test:
     needs: build
@@ -72,3 +73,4 @@ jobs:
           draft: true
           files: Fishstrap-${{ github.ref_name }}.exe
           name: Fishstrap ${{ github.ref_name }}
+          fail_on_unmatched_files: true


### PR DESCRIPTION
prevents situations like 910dc80 (you should've update the create release step as well)