### PR TITLE
Remove version from the exe name

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -44,13 +44,13 @@ jobs:
           path: release
 
       - name: Rename binaries
-        run: mv release/Fishstrap.exe Fishstrap-${{ github.ref_name }}.exe
+        run: mv release/Fishstrap.exe Fishstrap.exe
 
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           draft: true
-          files: Fishstrap-${{ github.ref_name }}.exe
+          files: Fishstrap.exe
           name: Fishstrap ${{ github.ref_name }}
           fail_on_unmatched_files: true
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -69,12 +69,12 @@ jobs:
           path: release
 
       - name: Rename binaries
-        run: mv release/Fishstrap.exe Fishstrap-${{ github.ref_name }}.exe
+        run: mv release/Fishstrap.exe Fishstrap.exe
 
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           draft: true
-          files: Fishstrap-${{ github.ref_name }}.exe
+          files: Fishstrap.exe
           name: Fishstrap ${{ github.ref_name }}
           fail_on_unmatched_files: true


### PR DESCRIPTION
Will let me directly link the latest version of Fishstrap on the website instead of needing to call the github api to figure out which version is the latest. i.e.:

```
https://github.com/fishstrap/fishstrap/releases/latest/download/Fishstrap.exe
```
Will directly download the latest version of Fishstrap. I have no idea why I didn't do this instead of stupidly asking the github api every time to figure out what the latest version of the release is.

Hopefully doesn't break the autoupdater (hopefully)