### PR TITLE
Invisible Text Fix

### DIFF
--- a/Bloxstrap/UI/Elements/Controls/OptionControl.xaml
+++ b/Bloxstrap/UI/Elements/Controls/OptionControl.xaml
@@ -10,9 +10,14 @@
              mc:Ignorable="d" 
              x:Name="Control"
              d:DesignHeight="450" d:DesignWidth="800">
-    <ui:CardControl Margin="0,8,0,0" Content="{Binding InnerContent, ElementName=Control}">
-        <ui:CardControl.Header>
-            <StackPanel>
+    <ui:Card Margin="0,8,0,0">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0" VerticalAlignment="Center">
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -65,6 +70,8 @@
                     </local:MarkdownTextBlock.Style>
                 </local:MarkdownTextBlock>
             </StackPanel>
-        </ui:CardControl.Header>
-    </ui:CardControl>
+
+            <ContentControl Grid.Column="1" VerticalAlignment="Center" Margin="16,0,0,0" Content="{Binding InnerContent, ElementName=Control}" />
+        </Grid>
+    </ui:Card>
 </UserControl>


### PR DESCRIPTION
This pr fixes the invisible text issue some ppl might get
it happens because cardcontrol is ahh lowkey
ss of how invis text looks like
<img width="1000" height="580" alt="image" src="https://github.com/user-attachments/assets/e9277db0-4682-476f-93d7-d1563c880480" />
<img width="1000" height="580" alt="image" src="https://github.com/user-attachments/assets/1adb9249-1553-45ae-b417-df35cc7c53dc" />
