### PR TITLE
chore: bump actions

### DIFF
--- a/.github/workflows/ci-debug.yml
+++ b/.github/workflows/ci-debug.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -24,7 +24,8 @@ jobs:
       run: dotnet publish -p:PublishSingleFile=true -p:CommitHash=${{ github.sha }} -p:CommitRef=${{ github.ref_type }}/${{ github.ref_name }} -r win-x64 -c Debug --self-contained false .\Bloxstrap\Bloxstrap.csproj
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
-        name: Fishstrap (Debug) (${{ github.sha }})
-        path: .\Bloxstrap\bin\Debug\net6.0-windows\win-x64\publish\*
+        #name: Fishstrap (Debug) (${{ github.sha }})
+        path: .\Bloxstrap\bin\Debug\net6.0-windows\win-x64\publish\Fishstrap.exe
+        archive: false

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -24,10 +24,11 @@ jobs:
       run: dotnet publish -p:PublishSingleFile=true -p:CommitHash=${{ github.sha }} -p:CommitRef=${{ github.ref_type }}/${{ github.ref_name }} -r win-x64 -c Release --self-contained false .\Bloxstrap\Bloxstrap.csproj
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
-        name: Fishstrap (Release) (${{ github.sha }})
-        path: .\Bloxstrap\bin\Release\net6.0-windows\win-x64\publish\*
+        #name: Fishstrap (Release) (${{ github.sha }})
+        path: .\Bloxstrap\bin\Release\net6.0-windows\win-x64\publish\Fishstrap.exe
+        archive: false
 
   release:
     needs: build
@@ -38,13 +39,13 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: Fishstrap (Release) (${{ github.sha }})
-          path: release
+        uses: actions/download-artifact@v8
+        #with:
+        #  name: Fishstrap (Release) (${{ github.sha }})
+        #  path: release
 
-      - name: Rename binaries
-        run: mv release/Fishstrap.exe Fishstrap.exe
+      #- name: Rename binaries
+      #  run: mv release/Fishstrap.exe Fishstrap.exe
 
       - name: Create release
         uses: softprops/action-gh-release@v2
@@ -63,13 +64,13 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: Fishstrap (Release) (${{ github.sha }})
-          path: release
+        uses: actions/download-artifact@v8
+        #with:
+        #  name: Fishstrap (Release) (${{ github.sha }})
+        #  path: release
 
-      - name: Rename binaries
-        run: mv release/Fishstrap.exe Fishstrap.exe
+      #- name: Rename binaries
+      #  run: mv release/Fishstrap.exe Fishstrap.exe
 
       - name: Create release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
From now on, we will be uploading the executable itself instead of the archive as an artifact.

Fields that are no longer required were commented out.