### PR TITLE
Fix Server Type Private/Reserved

### DIFF
--- a/Bloxstrap/Enums/ServerSessionJoinType.cs
+++ b/Bloxstrap/Enums/ServerSessionJoinType.cs
@@ -1,0 +1,12 @@
+﻿namespace Bloxstrap.Enums
+{
+    public enum ServerSessionJoinType
+    {
+        NewGameNoAvailableSlots = 1,
+        NewGameSinglePlayer = 2,
+        NewGamePrivateGame = 4,
+        Specific = 5,
+        SpecificPrivateGame = 6,
+        MatchMade = 10,
+    }
+}

--- a/Bloxstrap/Integrations/ActivityWatcher.cs
+++ b/Bloxstrap/Integrations/ActivityWatcher.cs
@@ -298,10 +298,10 @@
                     var joinTypeMatch = Regex.Match(logMessage, GameTeleportJoinTypePattern);
                     if (joinTypeMatch.Success)
                     {
-                        int joinTypeId = int.Parse(joinTypeMatch.Groups[1].Value);
+                        var joinTypeId = (ServerSessionJoinType)int.Parse(joinTypeMatch.Groups[1].Value);
                         App.Logger.WriteLine(LOG_IDENT, $"Teleport JoinTypeId: {joinTypeId}");
 
-                        if (joinTypeId == 4 || joinTypeId == 6)
+                        if (joinTypeId is ServerSessionJoinType.NewGamePrivateGame or ServerSessionJoinType.SpecificPrivateGame)
                         {
                             _reservedTeleportMarker = true;
                             App.Logger.WriteLine(LOG_IDENT, "Detected reserved server teleport");

--- a/Bloxstrap/Integrations/ActivityWatcher.cs
+++ b/Bloxstrap/Integrations/ActivityWatcher.cs
@@ -12,7 +12,6 @@
 
         // gamejoinutil string no longer work lol
         private const string GameTeleportingEntry            = "[FLog::GameJoinUtil] GameJoinUtil::initiateTeleportToPlace";
-        private const string GameJoiningPrivateServerEntry   = "[FLog::GameJoinUtil] GameJoinUtil::joinGamePostPrivateServer";
         private const string GameJoiningReservedServerEntry  = "[FLog::GameJoinUtil] GameJoinUtil::initiateTeleportToReservedServer";
         private const string GameJoiningUniverseEntry        = "[FLog::GameJoinLoadTime] Report game_join_loadtime:";
         private const string GameJoiningUDMUXEntry           = "[FLog::Network] UDMUX Address = ";
@@ -22,7 +21,7 @@
         private const string GameServerUptimeEntry           = "[FLog::Output] Server Prefix: ";
 
         private const string GameJoiningEntryPattern         = @"! Joining game '([0-9a-f\-]{36})' place ([0-9]+) at ([0-9\.]+)";
-        private const string GameJoiningPrivateServerPattern = @"""accessCode"":""([0-9a-f\-]{36})""";
+        private const string GameJoinReferralPattern         = @"referral_page:([^,]+)";
         private const string GameJoiningUniversePattern      = @"universeid:([0-9]+).*userid:([0-9]+)";
         private const string GameJoiningUDMUXPattern         = @"UDMUX Address = ([0-9\.]+), Port = [0-9]+ \| RCC Server Address = ([0-9\.]+), Port = [0-9]+";
         private const string GameJoinedEntryPattern          = @"serverId: ([0-9\.]+)\|[0-9]+";
@@ -176,24 +175,7 @@
             if (!InGame && Data.PlaceId == 0)
             {
                 // We are not in a game, nor are in the process of joining one
-                if (logMessage.StartsWith(GameJoiningPrivateServerEntry))
-                {
-                    // we only expect to be joining a private server if we're not already in a game
-
-                    Data.ServerType = ServerType.Private;
-
-                    var match = Regex.Match(logMessage, GameJoiningPrivateServerPattern);
-
-                    if (match.Groups.Count != 2)
-                    {
-                        App.Logger.WriteLine(LOG_IDENT, "Failed to assert format for game join private server entry");
-                        App.Logger.WriteLine(LOG_IDENT, logMessage);
-                        return;
-                    }
-
-                    Data.AccessCode = match.Groups[1].Value;
-                }
-                else if (logMessage.StartsWith(GameJoiningEntry))
+                if (logMessage.StartsWith(GameJoiningEntry))
                 {
                     Match match = Regex.Match(logMessage, GameJoiningEntryPattern);
 
@@ -241,6 +223,16 @@
 
                     Data.UniverseId = Int64.Parse(match.Groups[1].Value);
                     Data.UserId = Int64.Parse(match.Groups[2].Value);
+
+                    var loadTimeMatch = Regex.Match(logMessage, GameJoinReferralPattern);
+
+                    if (loadTimeMatch.Groups.Count == 2)
+                    {
+                        string referral = loadTimeMatch.Groups[1].Value;
+
+                        if (referral.Contains("RequestPrivateGame", StringComparison.OrdinalIgnoreCase) || referral.Contains("GameDetailPageJSHybridEvent", StringComparison.OrdinalIgnoreCase))
+                            Data.ServerType = ServerType.Private;
+                    }
 
                     if (History.Any())
                     {

--- a/Bloxstrap/Integrations/ActivityWatcher.cs
+++ b/Bloxstrap/Integrations/ActivityWatcher.cs
@@ -385,14 +385,14 @@
 
                     LastRPCRequest = DateTime.Now;
                 }
-                else if (entry.Contains(GameServerUptimeEntry))
+                else if (logMessage.StartsWith(GameServerUptimeEntry))
                 {
-                    Match match = Regex.Match(entry, GameServerUptimePattern);
+                    Match match = Regex.Match(logMessage, GameServerUptimePattern);
 
                     if (!match.Success && match.Groups.Count == 2)
                     {
                         App.Logger.WriteLine(LOG_IDENT, $"Failed to assert format for server uptime entry");
-                        App.Logger.WriteLine(LOG_IDENT, entry);
+                        App.Logger.WriteLine(LOG_IDENT, logMessage);
                         return;
                     }
 

--- a/Bloxstrap/Integrations/ActivityWatcher.cs
+++ b/Bloxstrap/Integrations/ActivityWatcher.cs
@@ -296,17 +296,19 @@
                     App.Logger.WriteLine(LOG_IDENT, $"Initiating teleport to server ({Data})");
                     _teleportMarker = true;
                     var joinTypeMatch = Regex.Match(logMessage, GameTeleportJoinTypePattern);
-                    if (joinTypeMatch.Success)
+                    if (joinTypeMatch.Success && int.TryParse(joinTypeMatch.Groups[1].Value, out int joinTypeId))
                     {
-                        var joinTypeId = (ServerSessionJoinType)int.Parse(joinTypeMatch.Groups[1].Value);
+                        var joinType = (ServerSessionJoinType)joinTypeId;
                         App.Logger.WriteLine(LOG_IDENT, $"Teleport JoinTypeId: {joinTypeId}");
 
-                        if (joinTypeId is ServerSessionJoinType.NewGamePrivateGame or ServerSessionJoinType.SpecificPrivateGame)
+                        if (joinType is ServerSessionJoinType.NewGamePrivateGame or ServerSessionJoinType.SpecificPrivateGame)
                         {
                             _reservedTeleportMarker = true;
                             App.Logger.WriteLine(LOG_IDENT, "Detected reserved server teleport");
                         }
                     }
+                    else
+                        App.Logger.WriteLine(LOG_IDENT, "Failed to detect teleport type");
                 }
                 else if (logMessage.StartsWith(GameMessageEntry))
                 {

--- a/Bloxstrap/Integrations/ActivityWatcher.cs
+++ b/Bloxstrap/Integrations/ActivityWatcher.cs
@@ -10,9 +10,7 @@
         // they only get printed depending on their configured FLog level, which could change at any time
         // while levels being changed is fairly rare, please limit the number of varying number of FLog types you have to use, if possible
 
-        // gamejoinutil string no longer work lol
-        private const string GameTeleportingEntry            = "[FLog::GameJoinUtil] GameJoinUtil::initiateTeleportToPlace";
-        private const string GameJoiningReservedServerEntry  = "[FLog::GameJoinUtil] GameJoinUtil::initiateTeleportToReservedServer";
+        private const string GameTeleportingEntry            = "[FLog::UgcExperienceController] UgcExperienceController: doTeleport: joinScriptUrl";
         private const string GameJoiningUniverseEntry        = "[FLog::GameJoinLoadTime] Report game_join_loadtime:";
         private const string GameJoiningUDMUXEntry           = "[FLog::Network] UDMUX Address = ";
         private const string GameJoinedEntry                 = "[FLog::Network] serverId:";
@@ -22,6 +20,7 @@
 
         private const string GameJoiningEntryPattern         = @"! Joining game '([0-9a-f\-]{36})' place ([0-9]+) at ([0-9\.]+)";
         private const string GameJoinReferralPattern         = @"referral_page:([^,]+)";
+        private const string GameTeleportJoinTypePattern     = @"JoinTypeId""%3a(\d+)%2c";
         private const string GameJoiningUniversePattern      = @"universeid:([0-9]+).*userid:([0-9]+)";
         private const string GameJoiningUDMUXPattern         = @"UDMUX Address = ([0-9\.]+), Port = [0-9]+ \| RCC Server Address = ([0-9\.]+), Port = [0-9]+";
         private const string GameJoinedEntryPattern          = @"serverId: ([0-9\.]+)\|[0-9]+";
@@ -31,7 +30,7 @@
         private int _logEntriesRead = 0;
         private bool _teleportMarker = false;
         private bool _reservedTeleportMarker = false;
-        
+
         public event EventHandler<string>? OnLogEntry;
         public event EventHandler? ShowNotif;
         public event EventHandler? OnGameJoin;
@@ -296,11 +295,18 @@
                 {
                     App.Logger.WriteLine(LOG_IDENT, $"Initiating teleport to server ({Data})");
                     _teleportMarker = true;
-                }
-                else if (logMessage.StartsWith(GameJoiningReservedServerEntry))
-                {
-                    _teleportMarker = true;
-                    _reservedTeleportMarker = true;
+                    var joinTypeMatch = Regex.Match(logMessage, GameTeleportJoinTypePattern);
+                    if (joinTypeMatch.Success)
+                    {
+                        int joinTypeId = int.Parse(joinTypeMatch.Groups[1].Value);
+                        App.Logger.WriteLine(LOG_IDENT, $"Teleport JoinTypeId: {joinTypeId}");
+
+                        if (joinTypeId == 4 || joinTypeId == 6)
+                        {
+                            _reservedTeleportMarker = true;
+                            App.Logger.WriteLine(LOG_IDENT, "Detected reserved server teleport");
+                        }
+                    }
                 }
                 else if (logMessage.StartsWith(GameMessageEntry))
                 {
@@ -378,7 +384,8 @@
                     OnRPCMessage?.Invoke(this, message);
 
                     LastRPCRequest = DateTime.Now;
-                } else if (entry.Contains(GameServerUptimeEntry))
+                }
+                else if (entry.Contains(GameServerUptimeEntry))
                 {
                     Match match = Regex.Match(entry, GameServerUptimePattern);
 

--- a/Bloxstrap/RobloxInterfaces/Deployment.cs
+++ b/Bloxstrap/RobloxInterfaces/Deployment.cs
@@ -182,7 +182,7 @@ namespace Bloxstrap.RobloxInterfaces
                 channel = "live";
 
             if (channel == "live")
-                return true;
+                return false;
 
             try
             {


### PR DESCRIPTION
Fixes server types being broken due to Roblox removing "GameJoinUtil" log entries.
Also fixed production/live getting counted as private channels while i was at it.
These changes need more testing.