### PR TITLE
Fix non-English languages players Change other languages still display english questions

### DIFF
--- a/Bloxstrap/Bloxstrap.csproj
+++ b/Bloxstrap/Bloxstrap.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>True</UseWindowsForms>
@@ -76,7 +76,6 @@
     <PackageReference Include="securifybv.ShellLink" Version="0.1.0" />
     <PackageReference Include="SharpVectors.Wpf" Version="1.8.4.2" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
     <PackageReference Include="XamlAnimatedGif" Version="2.3.0" />
   </ItemGroup>
 

--- a/Bloxstrap/Locale.cs
+++ b/Bloxstrap/Locale.cs
@@ -4,6 +4,8 @@ namespace Bloxstrap
 {
     internal static class Locale
     {
+        private static readonly CultureInfo _systemDefaultCulture = CultureInfo.CurrentUICulture;
+
         public static CultureInfo CurrentCulture { get; private set; } = CultureInfo.InvariantCulture;
 
         public static bool RightToLeft { get; private set; } = false;
@@ -96,7 +98,10 @@ namespace Bloxstrap
 
             if (identifier == "nil")
             {
-                CurrentCulture = Thread.CurrentThread.CurrentUICulture;
+                CurrentCulture = _systemDefaultCulture;
+
+                CultureInfo.DefaultThreadCurrentUICulture = null;
+                Thread.CurrentThread.CurrentUICulture = CurrentCulture;
             }
             else
             {

--- a/Bloxstrap/UI/Elements/Settings/Pages/AppearancePage.xaml
+++ b/Bloxstrap/UI/Elements/Settings/Pages/AppearancePage.xaml
@@ -28,7 +28,7 @@
         <controls:OptionControl
             Header="{x:Static resources:Strings.Menu_Appearance_Language_Title}"
             Description="{x:Static resources:Strings.Menu_Appearance_Language_Description}">
-            <ComboBox Width="200" Padding="10,5,10,5" ItemsSource="{Binding Languages, Mode=OneTime}" Text="{Binding SelectedLanguage, Mode=TwoWay}" />
+            <ComboBox Width="200" Padding="10,5,10,5" ItemsSource="{Binding Languages, Mode=OneTime}" SelectedItem="{Binding SelectedLanguage, Mode=TwoWay}" />
         </controls:OptionControl>
 
         <!--<controls:OptionControl

--- a/Bloxstrap/UI/ViewModels/Settings/AppearanceViewModel.cs
+++ b/Bloxstrap/UI/ViewModels/Settings/AppearanceViewModel.cs
@@ -128,7 +128,15 @@ namespace Bloxstrap.UI.ViewModels.Settings
         public string SelectedLanguage
         {
             get => Locale.SupportedLocales[App.Settings.Prop.Locale];
-            set => App.Settings.Prop.Locale = Locale.GetIdentifierFromName(value);
+            set
+            {
+                string identifier = Locale.GetIdentifierFromName(value);
+
+                App.Settings.Prop.Locale = identifier;
+                Locale.Set(identifier);
+
+                OnPropertyChanged(nameof(SelectedLanguage));
+            }
         }
 
         public IEnumerable<BootstrapperStyle> Dialogs { get; } = BootstrapperStyleEx.Selections;

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.428"
+    "version": "10.0.300",
+    "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,5 @@
 {
   "sdk": {
-    "version": "10.0.300",
-    "rollForward": "latestMinor"
+    "version": "8.0.420"
   }
 }


### PR DESCRIPTION
Hello, I'm using Claude code to help me fix this. I tried fixing it in .NET 6.0, but hmm, Chinese characters still aren't working. However, updating to .NET 8.0 is working. Then I changed the system default locale cache in locale.cs and removed the resourcemanager, which causes certain languages ​​like JP and CN to not work. I think it might be some kind of update breaking .NET 6.0, but I can only try upgrading this, But that problem successfully gone. I'm sorry, I used AI, but AI did solve this problem, and I also built the test. Then I translated this Pr's from Chinese into English ,
, My expression may not be so good. and changed lang is working.


fix before:
<img width="982" height="559" alt="Screenshot 2026-06-22 205941" src="https://github.com/user-attachments/assets/a3e47d88-351f-4d46-b180-eece3dde82fb" />

fixed:
<img width="586" height="266" alt="Screenshot 2026-06-22 205953" src="https://github.com/user-attachments/assets/af4dcf61-8e2b-46d1-976f-7e4d61d01e58" />
